### PR TITLE
Add option to make status bar icon and page indicator dark

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Pixel Launcher Enhanced is an Xposed module designed to unlock a variety of exci
 | Wallpaper zooming       |       ✅        |         ✅          |
 | Hide statusbar          |       ✅        |         ✅          |
 | Hide top shadow         |       ✅        |         ✅          |
+| Dark statusbar icon     |       ✅        |         ✅          |
+| Dark page indicator     |       ✅        |         ✅          |
 | Icon labels on desktop  |       ✅        |         ✅          |
 | Homescreen columns      |       ✅        |         ✅          |
 | Homescreen rows         |       ✅        |         ✅          |

--- a/app/src/main/java/com/drdisagree/pixellauncherenhanced/data/common/Constants.kt
+++ b/app/src/main/java/com/drdisagree/pixellauncherenhanced/data/common/Constants.kt
@@ -28,6 +28,8 @@ object Constants {
     const val ALLOW_WALLPAPER_ZOOMING = "xposed_allowwallpaperzooming"
     const val LAUNCHER_HIDE_STATUSBAR = "xposed_launcherhidestatusbar"
     const val LAUNCHER_HIDE_TOP_SHADOW = "xposed_launcherhidetopshadow"
+    const val LAUNCHER_DARK_STATUSBAR = "xposed_launcherdarkstatusbar"
+    const val LAUNCHER_DARK_PAGE_INDICATOR = "xposed_launcherdarkpageindicator"
     const val DESKTOP_ICON_LABELS = "xposed_desktopiconlabels"
     const val APP_DRAWER_ICON_LABELS = "xposed_appdrawericonlabels"
     const val HIDE_AT_A_GLANCE = "xposed_hideataglance"

--- a/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/EntryList.kt
+++ b/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/EntryList.kt
@@ -3,6 +3,8 @@ package com.drdisagree.pixellauncherenhanced.xposed
 import com.drdisagree.pixellauncherenhanced.data.common.Constants.LAUNCHER3_PACKAGE
 import com.drdisagree.pixellauncherenhanced.data.common.Constants.PIXEL_LAUNCHER_PACKAGE
 import com.drdisagree.pixellauncherenhanced.xposed.mods.ClearAllButton
+import com.drdisagree.pixellauncherenhanced.xposed.mods.DarkPageIndicator
+import com.drdisagree.pixellauncherenhanced.xposed.mods.DarkStatusbar
 import com.drdisagree.pixellauncherenhanced.xposed.mods.DrawerSearchbar
 import com.drdisagree.pixellauncherenhanced.xposed.mods.FreeformMod
 import com.drdisagree.pixellauncherenhanced.xposed.mods.GestureMod
@@ -53,7 +55,9 @@ object EntryList {
         ShortcutBadge::class.java,
         WallpaperZoom::class.java,
         QuickLaunch::class.java,
-        TaskbarHandle::class.java
+        TaskbarHandle::class.java,
+        DarkStatusbar::class.java,
+        DarkPageIndicator::class.java,
     )
 
     fun getEntries(packageName: String): ArrayList<Class<out ModPack>> {

--- a/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/mods/DarkPageIndicator.kt
+++ b/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/mods/DarkPageIndicator.kt
@@ -1,0 +1,42 @@
+package com.drdisagree.pixellauncherenhanced.xposed.mods
+
+import android.content.Context
+import android.graphics.Color
+import com.drdisagree.pixellauncherenhanced.data.common.Constants.LAUNCHER_DARK_PAGE_INDICATOR
+import com.drdisagree.pixellauncherenhanced.xposed.ModPack
+import com.drdisagree.pixellauncherenhanced.xposed.mods.LauncherUtils.Companion.restartLauncher
+import com.drdisagree.pixellauncherenhanced.xposed.mods.toolkit.XposedHook.Companion.findClass
+import com.drdisagree.pixellauncherenhanced.xposed.mods.toolkit.callMethod
+import com.drdisagree.pixellauncherenhanced.xposed.mods.toolkit.getField
+import com.drdisagree.pixellauncherenhanced.xposed.mods.toolkit.hookMethod
+import com.drdisagree.pixellauncherenhanced.xposed.utils.XPrefs.Xprefs
+import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
+
+class DarkPageIndicator (context: Context) : ModPack(context) {
+
+    private var darkPageIndicatorEnabled = false
+
+    override fun updatePrefs(vararg key: String) {
+        Xprefs.apply {
+            darkPageIndicatorEnabled = getBoolean(LAUNCHER_DARK_PAGE_INDICATOR, false)
+        }
+
+        when (key.firstOrNull()) {
+            LAUNCHER_DARK_PAGE_INDICATOR -> restartLauncher(mContext)
+        }
+    }
+
+    override fun handleLoadPackage(loadPackageParam: LoadPackageParam) {
+        val launcherClass = findClass("com.android.launcher3.Launcher")!!
+
+        launcherClass
+            .hookMethod("setupViews")
+            .runAfter({param ->
+                if (darkPageIndicatorEnabled) {
+                    param.thisObject.getField("mWorkspace")
+                        .callMethod("getPageIndicator")
+                        .callMethod("setPaintColor", Color.BLACK)
+                }
+            })
+    }
+}

--- a/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/mods/DarkStatusbar.kt
+++ b/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/mods/DarkStatusbar.kt
@@ -1,0 +1,54 @@
+package com.drdisagree.pixellauncherenhanced.xposed.mods
+
+import android.content.Context
+import com.drdisagree.pixellauncherenhanced.data.common.Constants.LAUNCHER_DARK_STATUSBAR
+import com.drdisagree.pixellauncherenhanced.xposed.ModPack
+import com.drdisagree.pixellauncherenhanced.xposed.mods.LauncherUtils.Companion.restartLauncher
+import com.drdisagree.pixellauncherenhanced.xposed.mods.toolkit.XposedHook.Companion.findClass
+import com.drdisagree.pixellauncherenhanced.xposed.mods.toolkit.callMethod
+import com.drdisagree.pixellauncherenhanced.xposed.mods.toolkit.hookMethod
+import com.drdisagree.pixellauncherenhanced.xposed.utils.XPrefs.Xprefs
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
+
+class DarkStatusbar (context: Context) : ModPack(context) {
+    companion object {
+        const val UI_STATE_BASE_WINDOW = 0
+        const val FLAG_LIGHT_STATUS: Int = 1 shl 2
+    }
+
+    private var darkStatusbarEnabled = false
+
+    override fun updatePrefs(vararg key: String) {
+        Xprefs.apply {
+            darkStatusbarEnabled = getBoolean(LAUNCHER_DARK_STATUSBAR, false)
+        }
+
+        when (key.firstOrNull()) {
+            LAUNCHER_DARK_STATUSBAR -> restartLauncher(mContext)
+        }
+    }
+
+    private fun forceDark(param: XC_MethodHook.MethodHookParam) {
+        if (!darkStatusbarEnabled) {
+            return
+        }
+
+        param.thisObject.callMethod("getSystemUiController")
+            .callMethod("updateUiState", UI_STATE_BASE_WINDOW, FLAG_LIGHT_STATUS)
+    }
+
+    override fun handleLoadPackage(loadPackageParam: LoadPackageParam) {
+        val launcherClass = findClass("com.android.launcher3.Launcher")!!
+
+        launcherClass
+            .hookMethod("onCreate")
+            .runAfter(::forceDark)
+
+        val recentsActivityClass = findClass("com.android.quickstep.RecentsActivity")!!
+
+        recentsActivityClass
+            .hookMethod("onCreate")
+            .runAfter(::forceDark)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,8 @@
     <string name="hide_launcher_statusbar_desc">Expand quick settings panel once if status bar is not hidden</string>
     <string name="hide_launcher_top_shadow_title">Hide top shadow</string>
     <string name="hide_launcher_top_shadow_desc">Remove top shadow from home screen</string>
+    <string name="dark_launcher_statusbar_title">Force dark statusbar</string>
+    <string name="dark_launcher_page_indicator_title">Force dark page indicator</string>
     <string name="quick_launch_title">Quick Launch</string>
     <string name="quick_launch_desc">Launch apps directly from search by pressing enter</string>
     <string name="app_drawer_icon_labels_title">Icon labels in app drawer</string>

--- a/app/src/main/res/xml/home_screen_mods.xml
+++ b/app/src/main/res/xml/home_screen_mods.xml
@@ -49,6 +49,18 @@
             app:iconSpaceReserved="false" />
 
         <com.drdisagree.pixellauncherenhanced.ui.preferences.SwitchPreference
+            android:defaultValue="false"
+            android:key="xposed_launcherdarkstatusbar"
+            android:title="@string/dark_launcher_statusbar_title"
+            app:iconSpaceReserved="false" />
+
+        <com.drdisagree.pixellauncherenhanced.ui.preferences.SwitchPreference
+            android:defaultValue="false"
+            android:key="xposed_launcherdarkpageindicator"
+            android:title="@string/dark_launcher_page_indicator_title"
+            app:iconSpaceReserved="false" />
+
+        <com.drdisagree.pixellauncherenhanced.ui.preferences.SwitchPreference
             android:defaultValue="true"
             android:key="xposed_desktopiconlabels"
             android:title="@string/desktop_icon_labels_title"


### PR DESCRIPTION
On light wallpaper, dark icons are much easier to read than light ones even with the the top shadow. There's already option to hide the top shadow, and I'd like to add an option to make status bar icons dark. Similar to the page indicator.