### PR TITLE
Prevent wallpaper dimming caused restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,13 @@ Pixel Launcher Enhanced is an Xposed module designed to unlock a variety of exci
 <details>
 <summary>Miscellaneous</summary>
 
-| Feature                         | Pixel Launcher | Launcher3 Launcher |
-|---------------------------------|:--------------:|:------------------:|
-| Hide gesture indicator          |       ✅        |         ✅          |
-| Show entry in launcher settings |       ✅        |         ✅          |
-| Developer options               |       ✅        |         🚫         |
-| Restart                         |       ✅        |         ✅          |
+| Feature                                  | Pixel Launcher | Launcher3 Launcher |
+|------------------------------------------|:--------------:|:------------------:|
+| Hide gesture indicator                   |       ✅        |         ✅          |
+| Show entry in launcher settings          |       ✅        |         ✅          |
+| Prevent wallpaper dimming caused restart |       ✅        |         ✅          |
+| Developer options                        |       ✅        |         🚫         |
+| Restart                                  |       ✅        |         ✅          |
 
 </details>
 

--- a/app/src/main/java/com/drdisagree/pixellauncherenhanced/data/common/Constants.kt
+++ b/app/src/main/java/com/drdisagree/pixellauncherenhanced/data/common/Constants.kt
@@ -65,6 +65,7 @@ object Constants {
     const val FREEFORM_GESTURE_PROGRESS = "xposed_startfreeformprogress"
     const val HIDE_GESTURE_PILL = "xposed_hidegesturepill"
     const val QUICK_LAUNCH = "xposed_quicklaunch"
+    const val PREVENT_WALLPAPER_DIMMING_RESTART = "xposed_preventwallpaperdimmingrestart"
 
     val PREF_UPDATE_EXCLUSIONS = listOf(
         BootLoopProtector.LOAD_TIME_KEY_KEY,

--- a/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/EntryList.kt
+++ b/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/EntryList.kt
@@ -2,6 +2,7 @@ package com.drdisagree.pixellauncherenhanced.xposed
 
 import com.drdisagree.pixellauncherenhanced.data.common.Constants.LAUNCHER3_PACKAGE
 import com.drdisagree.pixellauncherenhanced.data.common.Constants.PIXEL_LAUNCHER_PACKAGE
+import com.drdisagree.pixellauncherenhanced.xposed.mods.PreventWallpaperDimmingRestart
 import com.drdisagree.pixellauncherenhanced.xposed.mods.ClearAllButton
 import com.drdisagree.pixellauncherenhanced.xposed.mods.DarkPageIndicator
 import com.drdisagree.pixellauncherenhanced.xposed.mods.DarkStatusbar
@@ -58,6 +59,7 @@ object EntryList {
         TaskbarHandle::class.java,
         DarkStatusbar::class.java,
         DarkPageIndicator::class.java,
+        PreventWallpaperDimmingRestart::class.java,
     )
 
     fun getEntries(packageName: String): ArrayList<Class<out ModPack>> {

--- a/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/mods/PreventWallpaperDimmingRestart.kt
+++ b/app/src/main/java/com/drdisagree/pixellauncherenhanced/xposed/mods/PreventWallpaperDimmingRestart.kt
@@ -1,0 +1,30 @@
+package com.drdisagree.pixellauncherenhanced.xposed.mods
+
+import android.content.Context
+import com.drdisagree.pixellauncherenhanced.data.common.Constants.PREVENT_WALLPAPER_DIMMING_RESTART
+import com.drdisagree.pixellauncherenhanced.xposed.ModPack
+import com.drdisagree.pixellauncherenhanced.xposed.mods.toolkit.XposedHook.Companion.findClass
+import com.drdisagree.pixellauncherenhanced.xposed.mods.toolkit.hookMethod
+import com.drdisagree.pixellauncherenhanced.xposed.utils.XPrefs.Xprefs
+import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
+
+
+class PreventWallpaperDimmingRestart (context: Context) : ModPack(context) {
+
+    private var preventWallpaperDimmingRestartEnabled = false
+
+    override fun updatePrefs(vararg key: String) {
+        Xprefs.apply {
+            preventWallpaperDimmingRestartEnabled = getBoolean(PREVENT_WALLPAPER_DIMMING_RESTART, false)
+        }
+    }
+
+    override fun handleLoadPackage(loadPackageParam: LoadPackageParam) {
+        val wallpaperColorChangedListener = findClass("com.android.launcher3.util.WallpaperColorHints\$onColorsChangedListener$1")
+        wallpaperColorChangedListener.hookMethod("onColorsChanged").runBefore { param ->
+            if (preventWallpaperDimmingRestartEnabled) {
+                param.setResult(null)
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,8 @@
     <string name="folder_color_light_title">Folder color in light mode</string>
     <string name="folder_color_dark_title">Folder color in dark mode</string>
     <string name="search_bar_opacity_title">Search bar opacity</string>
+    <string name="prevent_wallpaper_dimming_restart_title">Prevent wallpaper dimming caused restart</string>
+    <string name="prevent_wallpaper_dimming_restart_summary">May need manual restart for launcher to pick up Live Wallpaper color update</string>
     <string name="value_output">Value: %s</string>
 
 </resources>

--- a/app/src/main/res/xml/miscellaneous_mods.xml
+++ b/app/src/main/res/xml/miscellaneous_mods.xml
@@ -16,6 +16,13 @@
         app:iconSpaceReserved="false" />
 
     <com.drdisagree.pixellauncherenhanced.ui.preferences.SwitchPreference
+        android:defaultValue="false"
+        android:key="xposed_preventwallpaperdimmingrestart"
+        android:summary="@string/prevent_wallpaper_dimming_restart_summary"
+        android:title="@string/prevent_wallpaper_dimming_restart_title"
+        app:iconSpaceReserved="false" />
+
+    <com.drdisagree.pixellauncherenhanced.ui.preferences.SwitchPreference
         android:key="xposed_developeroptions"
         android:summary="@string/developer_options_desc"
         android:title="@string/developer_options_title"


### PR DESCRIPTION
Enabling or disabling wallpaper dimming (for example, enable Modes > Bedtime > Display Settings > Dim the wallpaper and turn on/off bedtime mode) may change the return value of `WallpaperColors.getColorHints()` (flipping [`HINT_SUPPORTS_DARK_THEME`](https://developer.android.com/reference/android/app/WallpaperColors#HINT_SUPPORTS_DARK_THEME)). Pixel Launcher reacts to this change by recreate the base activity (effectively restarting the launcher):

```java
/* compiled from: go/retraceme f3a19d912c87c27267cfbc05ba0bc7b202ab72a6648bd76225f5f7e128d94583 */
/* loaded from: classes.dex */
public final class WallpaperColorHints$onColorsChangedListener$1 implements WallpaperManager.OnColorsChangedListener {
    public /* synthetic */ WallpaperColorHints this$0;

    @Override // android.app.WallpaperManager.OnColorsChangedListener
    public final void onColorsChanged(WallpaperColors wallpaperColors, int i10) {
        WallpaperColorHints wallpaperColorHints = this.this$0;
        if ((i10 & 1) != 0) {
            int colorHints = wallpaperColors != null ? wallpaperColors.getColorHints() : 0;
            if (colorHints != wallpaperColorHints.hints) {
                wallpaperColorHints.hints = colorHints;
                for (WallpaperThemeManager wallpaperThemeManager : wallpaperColorHints.onColorHintsChangedListeners) {
                    if (wallpaperThemeManager.themeRes != Themes.getActivityThemeRes(wallpaperThemeManager.activity)) {
                        wallpaperThemeManager.recreateToUpdateTheme = true;
                        wallpaperThemeManager.activity.recreate();
                    }
                }
            }
        }
    }
}
```

This resulted in a flash of black screen and resulted in bad UX. Add a toggle to prevent this restart behavior.